### PR TITLE
update example with increased timeout

### DIFF
--- a/sauce-features/visual/basic/spec/spec_helper.rb
+++ b/sauce-features/visual/basic/spec/spec_helper.rb
@@ -15,9 +15,13 @@ RSpec.configure do |config|
                                                                                projectName: 'visual-e2e-test',
                                                                                viewportSize: '1280x1024'})
 
+    http_client = Selenium::WebDriver::Remote::Http::Default.new
+    http_client.read_timeout = 90 # seconds
     @driver = Selenium::WebDriver.for :remote,
                                       url: 'https://hub.screener.io/wd/hub',
-                                      desired_capabilities: caps
+                                      desired_capabilities: caps,
+                                      :http_client => http_client
+    @driver.manage.timeouts.script_timeout = 90
   end
 
   config.after do

--- a/sauce-features/visual/basic/spec/spec_helper.rb
+++ b/sauce-features/visual/basic/spec/spec_helper.rb
@@ -15,7 +15,7 @@ RSpec.configure do |config|
                                                                                projectName: 'visual-e2e-test',
                                                                                viewportSize: '1280x1024'})
 
-    # On complex websites and browsers like internet explorer 11, you migth need to increase
+    # On complex websites and browsers like internet explorer 11, you might need to increase
     # scripts and connection timeout in order for visual to be able to capture UI snapshot
     http_client = Selenium::WebDriver::Remote::Http::Default.new
     http_client.read_timeout = 90 # seconds

--- a/sauce-features/visual/basic/spec/spec_helper.rb
+++ b/sauce-features/visual/basic/spec/spec_helper.rb
@@ -15,6 +15,8 @@ RSpec.configure do |config|
                                                                                projectName: 'visual-e2e-test',
                                                                                viewportSize: '1280x1024'})
 
+    # On complex websites and browsers like internet explorer 11, you migth need to increase
+    # scripts and connection timeout in order for visual to be able to capture UI snapshot
     http_client = Selenium::WebDriver::Remote::Http::Default.new
     http_client.read_timeout = 90 # seconds
     @driver = Selenium::WebDriver.for :remote,

--- a/sauce-features/visual/basic/spec/spec_helper.rb
+++ b/sauce-features/visual/basic/spec/spec_helper.rb
@@ -22,7 +22,7 @@ RSpec.configure do |config|
     @driver = Selenium::WebDriver.for :remote,
                                       url: 'https://hub.screener.io/wd/hub',
                                       desired_capabilities: caps,
-                                      :http_client => http_client
+                                      :http_client: http_client
     @driver.manage.timeouts.script_timeout = 90
   end
 

--- a/sauce-features/visual/basic/spec/spec_helper.rb
+++ b/sauce-features/visual/basic/spec/spec_helper.rb
@@ -22,7 +22,7 @@ RSpec.configure do |config|
     @driver = Selenium::WebDriver.for :remote,
                                       url: 'https://hub.screener.io/wd/hub',
                                       desired_capabilities: caps,
-                                      :http_client: http_client
+                                      http_client: http_client
     @driver.manage.timeouts.script_timeout = 90
   end
 


### PR DESCRIPTION
On complex customer pages, browsers like IE11 require extra time to process UI capture. Increasing this timeout can help customers having successful builds. 